### PR TITLE
Adiciona link pra acessar o gitbook para visitantes vindos do github

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![License](https://img.shields.io/aur/license/yaourt.svg?maxAge=2592000)](https://github.com/ThoughtWorksInc/guia-de-desenvolvimento-tecnico/blob/master/LICENSE)
 [![Build Status](https://snap-ci.com/ThoughtWorksInc/guia-de-desenvolvimento-tecnico/branch/master/build_image)](https://snap-ci.com/ThoughtWorksInc/guia-de-desenvolvimento-tecnico/branch/master)
 
+## [Acesse :link:](https://thoughtworksinc.github.io/guia-de-desenvolvimento-tecnico/)
+
 ## Visão
 
 * **Para** indivíduos e times


### PR DESCRIPTION
Para quem descobre o guia pelo link do gitbook, perfeito, tem todo o conteúdo ali.

Mas estava um tempo ser ver o guia e vim direto ao repositório no github, e fiquei perdido porque não sabia onde estava o conteúdo, já que se olha a pagina inicial do guia no github (https://github.com/ThoughtWorksInc/guia-de-desenvolvimento-tecnico), você só vê coisas como visão e introdução, e não tem ligação com o mais importante, o conteúdo

A idéia desse link então é mandar os usuários do github pro gitbook, o ruim é que fica redudante no gitbook

edit: agora que vi que também tem o link na descrição hahaha