### PR TITLE
Adiciona testes para links quebrados

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "gitbook serve",
     "build": "gitbook build",
     "test": "markdownlint --config lint.json {.,topics}/*.md",
+    "check-link-diff": "git diff origin/master | markdown-link-check",
+    "check-link-local": "cat topics/*.md | markdown-link-check",
     "watch": "onchange '**/*.md' -v -- npm test",
     "deploy": "npm run build && gh-pages -d _book"
   },
@@ -25,6 +27,7 @@
     "gitbook-cli": "^2.3.0",
     "gitbook-plugin-advanced-emoji": "^0.2.1",
     "gitbook-plugin-simple-page-toc": "^0.1.0",
+    "markdown-link-check": "^1.2.0",
     "markdownlint-cli": "^0.2.0",
     "onchange": "^2.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "gitbook build",
     "test": "markdownlint --config lint.json {.,topics}/*.md",
     "check-link-diff": "git diff origin/master | markdown-link-check",
-    "check-link-local": "cat topics/*.md | markdown-link-check",
+    "check-link-local": "cat *.md topics/*.md | markdown-link-check",
     "watch": "onchange '**/*.md' -v -- npm test",
     "deploy": "npm run build && gh-pages -d _book"
   },


### PR DESCRIPTION
Essa PR visa criar testes para garantir que novos links adicionados ao livro não estejam quebrados. Isso resolve um de dois monitoramentos de links que temos em mente: o de garantir que somente novos links não estão quebrados. A idéia é rodar esses testes em cada PR, antes de ser mergeada.

Teremos outra solução para monitoramento constante de links que já existem.

Relacionado a issue #25.