### PR TITLE
Adiciona link para editar página

### DIFF
--- a/book.json
+++ b/book.json
@@ -11,6 +11,7 @@
     "comment",
     "localized-footer",
     "simple-page-toc",
+    "edit-link",
     "advanced-emoji"
   ],
   "pluginsConfig": {
@@ -29,6 +30,10 @@
     },
     "localized-footer": {
       "filename": "layouts/FOOTER.md"
+    },
+    "edit-link": {
+      "base": "https://github.com/ThoughtWorksInc/guia-de-desenvolvimento-tecnico/blob/master",
+      "label": "Editar esta página"
     },
     "simple-page-toc": {
       "maxDepth": 2,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gitbook-cli": "^2.3.0",
     "gitbook-plugin-advanced-emoji": "^0.2.1",
     "gitbook-plugin-comment": "^1.0.5",
+    "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-git-author": "^1.1.2",
     "gitbook-plugin-githubcontributors": "^0.1.1",
     "gitbook-plugin-localized-footer": "^0.2.2",


### PR DESCRIPTION
Esse link aparece no topo da página e abre direto o arquivo que gera a página atual no Github. Ele é adicionado pelo plugin ["edit-link"](https://plugins.gitbook.com/plugin/edit-link) do Gitbook.

O que acham?