### PR TITLE
Adiciona mais referências na parte de SOLID

### DIFF
--- a/topics/Padroes_de_Codigo.md
+++ b/topics/Padroes_de_Codigo.md
@@ -72,7 +72,10 @@ método sobre objetos diferentes.
 
 ## SOLID
 
-SOLID é um acrônimo para os cinco princípios básicos de design de classes orientadas a objetos criados por Robert C. Martin (Uncle Bob). Princípios dão nomes a conceitos complexos sobre o cdigo, mas não são regras ou verdades absolutas.
+SOLID é um acrônimo para os cinco princípios básicos de design de classes
+orientadas a objetos criados por Robert C. Martin (Uncle Bob).
+Princípios dão nomes a conceitos complexos sobre o cdigo,
+mas não são regras ou verdades absolutas.
 
 * *Single responsibility principle* (princípio de responsabilidade única)
   O princípio de responsabilidade única define que uma classe ou método deveria

--- a/topics/Padroes_de_Codigo.md
+++ b/topics/Padroes_de_Codigo.md
@@ -72,8 +72,7 @@ método sobre objetos diferentes.
 
 ## SOLID
 
-SOLID é um acrônimo que engloba os cinco princípios básicos de orientação a
-objetos. Existem variações, mas em geral eles se resumem a:
+SOLID é um acrônimo para os cinco princípios básicos de design de classes orientadas a objetos criados por Robert C. Martin (Uncle Bob). Princípios dão nomes a conceitos complexos sobre o cdigo, mas não são regras ou verdades absolutas.
 
 * *Single responsibility principle* (princípio de responsabilidade única)
   O princípio de responsabilidade única define que uma classe ou método deveria
@@ -81,9 +80,9 @@ objetos. Existem variações, mas em geral eles se resumem a:
   responsabilidade seja completamente encapsulada pela entidade.
 * *Open/close principle* (princípio aberto/fechado)
   O princípio aberto/fechado dita que entidades de software deveriam ser abertas
-  à extensão, mas fechadas à modificação. A ideia é que essas entidades
-  (classes, objetos, métodos...) possam ter suas funcionalidades extendidas,
-  mas não seu código modificado.
+  à extensão, mas fechadas à modificação. A ideia é que essas classes
+  possam ter suas funcionalidades extendidas por outras classe sem a necessidade
+  de modificar seu código.
 * *Liskov substitution principle* (princípio da substituição de Liskov)
   Esse princípio visa definir o conceito de subtipo, garantindo que subtipos
   mantenham as propriedades defininas no tipo original. Esse princípio afirma
@@ -100,8 +99,13 @@ objetos. Existem variações, mas em geral eles se resumem a:
 
 ### Recursos
 
+* [[Artigo] The Principles of Object Oriented Design](http://butunclebob.com/ArticleS.UncleBob.PrinciplesOfOod)
+  :uk:
+* [[Artigo] Getting a SLOD start](https://sites.google.com/site/unclebobconsultingllc/getting-a-solid-start)
+  :uk:
 * [[Wikipedia] SOLID (object-oriented design)](https://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29)
   :uk:
+* [[Artigo] SOLID (série de artigos sobre os princípios)](https://brizeno.wordpress.com/solid/)
 
 ## Padrões de Projeto Orientado a Objeto
 

--- a/topics/Padroes_de_Codigo.md
+++ b/topics/Padroes_de_Codigo.md
@@ -74,7 +74,7 @@ método sobre objetos diferentes.
 
 SOLID é um acrônimo para os cinco princípios básicos de design de classes
 orientadas a objetos criados por Robert C. Martin (Uncle Bob).
-Princípios dão nomes a conceitos complexos sobre o cdigo,
+Princípios dão nomes a conceitos complexos sobre o código,
 mas não são regras ou verdades absolutas.
 
 * *Single responsibility principle* (princípio de responsabilidade única)
@@ -83,9 +83,9 @@ mas não são regras ou verdades absolutas.
   responsabilidade seja completamente encapsulada pela entidade.
 * *Open/close principle* (princípio aberto/fechado)
   O princípio aberto/fechado dita que entidades de software deveriam ser abertas
-  à extensão, mas fechadas à modificação. A ideia é que essas classes
-  possam ter suas funcionalidades extendidas por outras classe sem a necessidade
-  de modificar seu código.
+  à extensão, mas fechadas à modificação. A ideia é que essas entidades (Classes,
+  Módulos, Funções, etc.) possam ter suas funcionalidades extendidas por outras
+  classes sem a necessidade de modificar seu código.
 * *Liskov substitution principle* (princípio da substituição de Liskov)
   Esse princípio visa definir o conceito de subtipo, garantindo que subtipos
   mantenham as propriedades defininas no tipo original. Esse princípio afirma
@@ -104,7 +104,7 @@ mas não são regras ou verdades absolutas.
 
 * [[Artigo] The Principles of Object Oriented Design](http://butunclebob.com/ArticleS.UncleBob.PrinciplesOfOod)
   :uk:
-* [[Artigo] Getting a SLOD start](https://sites.google.com/site/unclebobconsultingllc/getting-a-solid-start)
+* [[Artigo] Getting a SOLID start](https://sites.google.com/site/unclebobconsultingllc/getting-a-solid-start)
   :uk:
 * [[Wikipedia] SOLID (object-oriented design)](https://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29)
   :uk:


### PR DESCRIPTION
Modifiquei um pouco o texto pra deixar mais explicito a referência ao trabalho do Uncle Bob , assim pessoas que estejam procurando mais coisas sobre o assunto podem saber de onde veio isso tudo.

Também fiz uma pequena correção na parte do Open Closed Principle pra remover uma parte que falava sobre entidades como classes, objetos ou métodos. Apesar de fazer sentido, os princípios SOLID se referem ao design de classes então acho que seria melhor deixar isso mais explícito no texto.