### PR TITLE
Adiciona integração com o disqus

### DIFF
--- a/book.json
+++ b/book.json
@@ -5,6 +5,7 @@
     "summary": "INDICE.md"
   },
   "plugins" : [
+    "disqus",
     "ga",
     "git-author",
     "githubcontributors",
@@ -15,6 +16,9 @@
     "advanced-emoji"
   ],
   "pluginsConfig": {
+    "disqus": {
+        "shortName": "guiadedesenvolvimentotw"
+    },
     "ga": {
       "token": "UA-86166823-1"
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "gitbook-plugin-githubcontributors": "^0.1.1",
     "gitbook-plugin-localized-footer": "^0.2.2",
     "gitbook-plugin-simple-page-toc": "^0.1.0",
+    "gitbook-plugin-disqus": "0.1.0",
+    "react": "15.0.1",
+    "react-dom": "15.0.1",
     "markdown-link-check": "^1.2.0",
     "markdownlint-cli": "^0.2.0",
     "onchange": "^2.5.0"


### PR DESCRIPTION
Olá, adicionei a integração com o disqus! 😄

Utilizei o plugin indicado pela @anikarni na issue #86, para isso eu precisei criar um novo site dentro do disqus.com, preciso que alguém me envie uma conta da tw dentro do disqus para transferir o site e adicionar mais pessoas moderadoras.

Outro detalhe, também é possível fazer comentários no readme(página inicial do guia), vamos deixar assim?

Screenshot de como ficou o plugin na página de analise de dados:
<img width="679" alt="screen shot 2017-01-15 at 2 16 36 pm" src="https://cloud.githubusercontent.com/assets/4137355/21964129/61e8c446-db2d-11e6-80dc-5690bba4f2a5.png">
  

Espero pelo feedback de vocês! ;)